### PR TITLE
Fix: Add thread-safe locking to NVIDIA GPU detection to prevent metrics endpoint hanging

### DIFF
--- a/gpustack_runtime/detector/nvidia.py
+++ b/gpustack_runtime/detector/nvidia.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import math
 import re
+import threading
 import time
 from _ctypes import byref
 from functools import lru_cache
@@ -75,10 +76,29 @@ class NVIDIADetector(Detector):
             return {}
         return {dev.address: dev for dev in pci_devs}
 
+    _detect_lock = threading.Lock()
+
     def __init__(self):
         super().__init__(ManufacturerEnum.NVIDIA)
 
-    def detect(self) -> Devices | None:  # noqa: PLR0915
+    def detect(self) -> Devices | None:
+        """
+        Detect NVIDIA GPUs using pynvml with thread-safe locking.
+
+        Returns:
+            A list of detected NVIDIA GPU devices,
+            or None if not supported.
+
+        Raises:
+            If there is an error during detection.
+
+        """
+        with self._detect_lock:
+            result = self._detect_impl()
+        
+        return result
+
+    def _detect_impl(self) -> Devices | None:  # noqa: PLR0915
         """
         Detect NVIDIA GPUs using pynvml.
 
@@ -97,7 +117,6 @@ class NVIDIADetector(Detector):
 
         try:
             pci_devs = NVIDIADetector.detect_pci_devices()
-
             pynvml.nvmlInit()
             if not envs.GPUSTACK_RUNTIME_DETECT_NO_TOOLKIT_CALL:
                 try:


### PR DESCRIPTION
Problem:
The metrics endpoint would hang after repeated calls, particularly under concurrent load.
Analysis revealed that pynvml.nvmlInit() was getting stuck,
causing the generate_latest() function to block indefinitely.

Root Cause:
The NVML library is not designed to handle frequent initialization/shutdown cycles.
The original detect() method invoked pynvml.nvmlInit() and pynvml.nvmlShutdown() on every request,
which destabilized the library and led to hanging behavior under load.

Solution:
1. Implement a class-level thread-safe locking mechanism using threading.Lock()
2. Refactor the detect() method into a wrapper function that acquires the lock before execution
3. Rename the original detect() implementation to _detect_impl() (per Python private method conventions)
4. Enforce exclusive access to GPU detection logic, ensuring only one thread can execute it at a time

This prevents concurrent initialization of the NVML library and resolves the hanging issue in the metrics endpoint.