### PR TITLE
fix(amd): close fd when amdgpu_device_initialize fails

### DIFF
--- a/gpustack_runtime/detector/pyamdgpu/__init__.py
+++ b/gpustack_runtime/detector/pyamdgpu/__init__.py
@@ -255,16 +255,26 @@ def amdgpu_device_initialize(card=1):
     except Exception:
         raise AMDGPUError(AMDGPU_ERROR_CARD_NOTFOUND)
 
-    c_major = c_uint32()
-    c_minor = c_uint32()
-    device = c_amdgpu_device_t()
-    fn = _amdgpuGetFunctionPointer("amdgpu_device_initialize")
-    # If receive an error print here, try
-    # sudo vim /etc/default/grub
-    # and add "amdgpu.dc=0" to GRUB_CMDLINE_LINUX_DEFAULT
-    # then run "sudo update-grub" and reboot.
-    ret = fn(fd, byref(c_major), byref(c_minor), byref(device))
-    _amdgpuCheckReturn(ret)
+    # libdrm_amdgpu takes ownership of ``fd`` only on success. On failure (or
+    # any other exception, including ``BaseException`` like KeyboardInterrupt)
+    # we must close it ourselves to avoid leaking fds — see gpustack/gpustack#5342.
+    initialized = False
+    try:
+        c_major = c_uint32()
+        c_minor = c_uint32()
+        device = c_amdgpu_device_t()
+        fn = _amdgpuGetFunctionPointer("amdgpu_device_initialize")
+        # If receive an error print here, try
+        # sudo vim /etc/default/grub
+        # and add "amdgpu.dc=0" to GRUB_CMDLINE_LINUX_DEFAULT
+        # then run "sudo update-grub" and reboot.
+        ret = fn(fd, byref(c_major), byref(c_minor), byref(device))
+        if ret == 0:
+            initialized = True
+        _amdgpuCheckReturn(ret)
+    finally:
+        if not initialized:
+            os.close(fd)
     return c_major.value, c_minor.value, device
 
 


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5342

``amdgpu_device_initialize`` opens ``/dev/dri/cardN`` via ``os.open`` and hands the fd to libdrm_amdgpu's ``amdgpu_device_initialize`` C function. On success, libdrm takes ownership and the matching ``amdgpu_device_deinitialize`` releases it; on failure (return code non-zero, raised here through ``_amdgpuCheckReturn``), the fd is not transferred and was being dropped without close, leaking one fd per invocation.

The AMD detector enters this fallback on iGPUs where ``amdsmi`` reports incomplete ASIC info (``dev_cores`` / ``dev_asic_family_id`` empty), and swallows the resulting ``AMDGPUError`` via ``contextlib.suppress``, so the leak is silent. Triggered every detect call — on a worker hit by a 5s Prometheus scrape this accumulates ~17K fds/day, each pinning roughly 190 KB of amdgpu per-context mapping (multi-GB anon RSS over days).

Reported as gpustack/gpustack#5342 (NVIDIA dGPU + AMD Radeon 780M iGPU hybrid host; 201K fds on ``/dev/dri/card1`` and 38 GiB anon RSS after ~10 days).