### PR TITLE
fix(iluvatar): move memory query out of health check condition

### DIFF
--- a/gpustack_runtime/detector/iluvatar.py
+++ b/gpustack_runtime/detector/iluvatar.py
@@ -137,15 +137,16 @@ class IluvatarDetector(Detector):
                 dev_mem = 0
                 dev_mem_used = 0
                 dev_mem_status = DeviceMemoryStatusEnum.HEALTHY
+                with contextlib.suppress(pyixml.NVMLError):
+                    dev_mem_info = pyixml.nvmlDeviceGetMemoryInfo(dev)
+                    dev_mem = byte_to_mebibyte(  # byte to MiB
+                        dev_mem_info.total,
+                    )
+                    dev_mem_used = byte_to_mebibyte(  # byte to MiB
+                        dev_mem_info.used,
+                    )
                 if not envs.GPUSTACK_RUNTIME_DETECT_NO_HEALTH_CHECK:
                     with contextlib.suppress(pyixml.NVMLError):
-                        dev_mem_info = pyixml.nvmlDeviceGetMemoryInfo(dev)
-                        dev_mem = byte_to_mebibyte(  # byte to MiB
-                            dev_mem_info.total,
-                        )
-                        dev_mem_used = byte_to_mebibyte(  # byte to MiB
-                            dev_mem_info.used,
-                        )
                         dev_health = pyixml.ixmlDeviceGetHealth(dev)
                         if dev_health != pyixml.IXML_HEALTH_OK:
                             dev_mem_status = DeviceMemoryStatusEnum.UNHEALTHY


### PR DESCRIPTION
在2.1.2版本上发现添加的worker节点不能正常读取天数智芯gpu信息
与runtime中的iluvatar.py中的显存检测有关系，默认的条件下会跳过显存检测导致web ui上不显示gpu信息
目前对gpu显存检测流程作了修改