### PR TITLE
fix(deployer): stop granting privilege to plugin-allocated devices

### DIFF
--- a/gpustack_runtime/deployer/kuberentes.py
+++ b/gpustack_runtime/deployer/kuberentes.py
@@ -325,6 +325,61 @@ def _pin_pod_for_kueue(
     }
 
 
+def _is_device_plugin_resource(resource_key: str) -> bool:
+    """
+    Report whether a resource key belongs to a device plugin resource family,
+    which is either a CDI kind ("nvidia.com/gpu") or one of its suffixed
+    variants ("nvidia.com/gpu.shared", "nvidia.com/gpu.sliced.units",
+    "nvidia.com/gpu.partitioned.mig-1g.20gb").
+    """
+    return any(
+        resource_key == cdi or resource_key.startswith(f"{cdi}.")
+        for cdi in envs.GPUSTACK_RUNTIME_DEPLOY_RESOURCE_KEY_MAP_CDI.values()
+    )
+
+
+def _resolve_privileged(container: Container) -> bool:
+    """
+    Resolve whether a container runs privileged.
+
+    Privilege is dropped when the container's devices are handed out by a
+    device plugin, which is the case for every device plugin resource family
+    and, under the KDP injection policy, for every mapped device request.
+
+    A privileged container receives all device nodes of the host, so it
+    enumerates -- and can use -- every accelerator on the node, no matter
+    which one the device plugin allocated to it. That silently undoes
+    slicing: a workload holding a single MIG device or a single memory slice
+    still sees the untouched cards next to it, and a soft-slicing limit
+    lands on whichever device comes first instead of the allocated one.
+    """
+    if not container.execution or not container.execution.privileged:
+        return False
+    if not container.resources:
+        return True
+
+    kdp = get_resource_injection_policy() == "kdp"
+    for r_k in container.resources:
+        if r_k in ("cpu", "memory"):
+            continue
+        if _is_device_plugin_resource(r_k) or (
+            kdp
+            and (
+                r_k
+                in envs.GPUSTACK_RUNTIME_DEPLOY_RESOURCE_KEY_MAP_RUNTIME_VISIBLE_DEVICES
+                or r_k == envs.GPUSTACK_RUNTIME_DEPLOY_AUTOMAP_RESOURCE_KEY
+            )
+        ):
+            clogger.info(
+                "Dropping privilege of container '%s', "
+                "as its device request '%s' is allocated by a device plugin",
+                container.name,
+                r_k,
+            )
+            return False
+    return True
+
+
 class KubernetesDeployer(EndoscopicDeployer):
     """
     Deployer implementation for Kubernetes.
@@ -1048,7 +1103,7 @@ class KubernetesDeployer(EndoscopicDeployer):
                     run_as_user=c.execution.run_as_user,
                     run_as_group=c.execution.run_as_group,
                     read_only_root_filesystem=c.execution.readonly_rootfs,
-                    privileged=c.execution.privileged,
+                    privileged=_resolve_privileged(c),
                     capabilities=(
                         kubernetes.client.V1Capabilities(
                             add=c.execution.capabilities.add,

--- a/tests/gpustack_runtime/deployer/test_privileged.py
+++ b/tests/gpustack_runtime/deployer/test_privileged.py
@@ -1,0 +1,137 @@
+import pytest
+
+from gpustack_runtime.deployer.__types__ import (
+    Container,
+    ContainerExecution,
+    ContainerResources,
+)
+from gpustack_runtime.deployer.kuberentes import _resolve_privileged
+
+
+def _container(privileged: bool | None, resources: dict | None = None) -> Container:
+    container_resources = None
+    if resources is not None:
+        container_resources = ContainerResources()
+        container_resources.update(resources)
+    return Container(
+        name="default",
+        image="gpustack/runner:latest",
+        execution=(
+            ContainerExecution(privileged=privileged)
+            if privileged is not None
+            else None
+        ),
+        resources=container_resources,
+    )
+
+
+@pytest.mark.parametrize(
+    "name, privileged, resources, policy, expected",
+    [
+        (
+            "no execution",
+            None,
+            None,
+            "env",
+            False,
+        ),
+        (
+            "not requested",
+            False,
+            {"nvidia.com/devices": "0"},
+            "env",
+            False,
+        ),
+        (
+            "no resources",
+            True,
+            None,
+            "env",
+            True,
+        ),
+        (
+            "non-device resources only",
+            True,
+            {"cpu": "2", "memory": "4Gi"},
+            "env",
+            True,
+        ),
+        (
+            "specific whole cards, env injection",
+            True,
+            {"cpu": "2", "nvidia.com/devices": "0,1"},
+            "env",
+            True,
+        ),
+        (
+            "all devices, env injection",
+            True,
+            {"nvidia.com/devices": "all"},
+            "env",
+            True,
+        ),
+        (
+            "specific whole cards, kdp injection",
+            True,
+            {"nvidia.com/devices": "0,1"},
+            "kdp",
+            False,
+        ),
+        (
+            "auto-mapped devices, kdp injection",
+            True,
+            {"gpustack.ai/devices": "0"},
+            "kdp",
+            False,
+        ),
+        (
+            "exclusive whole card",
+            True,
+            {"nvidia.com/gpu": "1"},
+            "env",
+            False,
+        ),
+        (
+            "soft slice",
+            True,
+            {
+                "nvidia.com/gpu.sliced": "1",
+                "nvidia.com/gpu.sliced.memory-percentage": "50",
+                "nvidia.com/gpu.sliced.cores-percentage": "50",
+            },
+            "env",
+            False,
+        ),
+        (
+            "hard partition",
+            True,
+            {
+                "nvidia.com/gpu.partitioned": "1",
+                "nvidia.com/gpu.partitioned.mig-1g.20gb": "1",
+            },
+            "env",
+            False,
+        ),
+        (
+            "non-NVIDIA soft slice",
+            True,
+            {"amd.com/gpu.sliced": "1"},
+            "env",
+            False,
+        ),
+        (
+            "resource key merely prefixed by a CDI kind",
+            True,
+            {"nvidia.com/gpu-alike": "1"},
+            "env",
+            True,
+        ),
+    ],
+)
+def test_resolve_privileged(name, privileged, resources, policy, expected, monkeypatch):
+    monkeypatch.setattr(
+        "gpustack_runtime.deployer.kuberentes.get_resource_injection_policy",
+        lambda: policy,
+    )
+    actual = _resolve_privileged(_container(privileged, resources))
+    assert actual == expected, f"case {name} expected {expected}, but got {actual}"


### PR DESCRIPTION
## What

A privileged container receives all device nodes of the host, so it enumerates — and can use — every accelerator on the node, whatever the device plugin allocated to it. On a multi-card node that undoes both slicing modes.

Drop privilege whenever the devices come from a device plugin: any device plugin resource family (`nvidia.com/gpu`, `nvidia.com/gpu.sliced*`, `nvidia.com/gpu.partitioned*`, and the same shapes for every other vendor in `GPUSTACK_RUNTIME_DEPLOY_RESOURCE_KEY_MAP_CDI`), and every mapped device request under the KDP injection policy. Device requests the deployer resolves itself through visible-devices envs keep their privilege, as does a container that asks for no device at all.

## Why — measured on an 8×H100 node with MIG enabled on exactly one card

Before, with `privileged: true` (which every GPUStack inference backend sets unconditionally):

| pod | `NVIDIA_VISIBLE_DEVICES` | `nvidia-smi -L` |
| --- | --- | --- |
| MIG, **not** privileged | its MIG UUID | GPU 0 + its one MIG device, nothing else |
| MIG, **privileged** | its MIG UUID (correct) | **all eight cards**, plus **both** MIG devices on card 0 — including another pod's |
| sliced 50 %, **privileged** | its whole-card UUID (correct) | **all eight cards**, plus both MIG devices on card 0 |

`NVIDIA_VISIBLE_DEVICES` is correct in all three, so it is not what enforces the bound — it is consumed by the container runtime at creation to decide which device nodes to mount, and a privileged container gets the whole `/dev` regardless.

The leak was functional, not cosmetic. In the sliced pod HAMi-core set `CUDA_DEVICE_MEMORY_LIMIT_0=40779m`; reported `memory.total` was `40779 MiB` at index 0 and `81559 MiB` **uncapped** at indexes 1–7. That pod was allocated `GPU-a158631e`, which was **index 1** inside the container — index 0 was the MIG card. Once the device set is not narrowed, a container-local `_LIMIT_0` no longer names the assigned card.

## After

Same node, two real vLLM model instances (`Qwen3.5-0.8B` on `gpustack/runner:cuda12.8-vllm0.17.1`):

| | By Ratio 50 % / 50 % | By Profile `3g.40gb` |
| --- | --- | --- |
| limits | `gpu.sliced: 1`, `sliced.memory-percentage: 50`, `sliced.cores-percentage: 50` | `gpu.partitioned: 1`, `partitioned.mig-3g.40gb: 1` |
| `privileged` | `false` | `false` |
| `nvidia-smi -L` | **one GPU**, its own — the other seven are gone | **GPU 0 + exactly one MIG device**, its own |
| `memory.total` | `40779 MiB` at index 0, which now *is* the allocated card | `[Insufficient Permissions]` (NVML refusing whole-card queries from inside a MIG container) |
| inference | `running`, `2+2` → `4` | `running`, `2+2` → `4` |

## Tests

`tests/gpustack_runtime/deployer/test_privileged.py` — 13 parametrized cases: no execution, privilege not requested, no resources, CPU/memory only, specific whole cards under `env` and under `kdp`, all-devices under `env`, auto-map under `kdp`, exclusive whole card, soft slice, hard partition, a non-NVIDIA soft slice, and the boundary case `nvidia.com/gpu-alike` (merely prefixed by a CDI kind — keeps its privilege).

`make test`: 62 passed, 16 skipped. `pre-commit` clean on both files.

## Not in scope

In `env` injection mode a privileged container asking for *specific* devices is deliberately widened to every device and then narrowed at the backend layer via `CUDA_VISIBLE_DEVICES`; `docker.py` / `podman.py` carry the identical shape. That predates this change and leaks the same way on a multi-card host, but it is not the Kubernetes divided-mode path.