### PR TITLE
fix(detector): stop AMD SMI's "N/A" sentinel from reaching numeric device fields

### DIFF
--- a/gpustack_runtime/detector/amd.py
+++ b/gpustack_runtime/detector/amd.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from .. import envs
 from ..logging import debug_log_exception, debug_log_warning
@@ -308,8 +309,14 @@ class AMDDetector(Detector):
                 dev_temp = None
                 try:
                     dev_gpu_metrics_info = pyamdsmi.amdsmi_get_gpu_metrics_info(dev)
-                    dev_cores_util = dev_gpu_metrics_info.get("average_gfx_activity", 0)
-                    dev_temp = dev_gpu_metrics_info.get("temperature_hotspot", 0)
+                    dev_cores_util = _get_reading(
+                        dev_gpu_metrics_info,
+                        "average_gfx_activity",
+                    )
+                    dev_temp = _get_reading(
+                        dev_gpu_metrics_info,
+                        "temperature_hotspot",
+                    )
                 except pyamdsmi.AmdSmiException:
                     with contextlib.suppress(pyrocmsmi.ROCMSMIError):
                         dev_cores_util = pyrocmsmi.rsmi_dev_busy_percent_get(dev_idx)
@@ -353,15 +360,21 @@ class AMDDetector(Detector):
                             if dev_ecc_count.uncorrectable_err > 0:
                                 dev_mem_status = DeviceMemoryStatusEnum.UNHEALTHY
 
+                # A sentinel reading means the same as a failed call -- AMD SMI
+                # cannot tell the used power -- so both route to ROCm SMI.
                 dev_power_used = None
-                try:
+                with contextlib.suppress(pyamdsmi.AmdSmiException):
                     dev_power_info = pyamdsmi.amdsmi_get_power_info(dev)
-                    dev_power_used = (
-                        dev_power_info.get("current_socket_power")
-                        if dev_power_info.get("current_socket_power", "N/A") != "N/A"
-                        else dev_power_info.get("average_socket_power", 0)
+                    dev_power_used = _get_reading(
+                        dev_power_info,
+                        "current_socket_power",
                     )
-                except pyamdsmi.AmdSmiException:
+                    if dev_power_used is None:
+                        dev_power_used = _get_reading(
+                            dev_power_info,
+                            "average_socket_power",
+                        )
+                if dev_power_used is None:
                     with contextlib.suppress(pyrocmsmi.ROCMSMIError):
                         dev_power_used = pyrocmsmi.rsmi_dev_power_get(dev_idx)
 
@@ -508,6 +521,31 @@ class AMDDetector(Detector):
             raise
 
         return ret
+
+
+def _get_reading(dev_info: dict, key: str, default: Any = None) -> Any:
+    """
+    Read one value out of an AMD SMI answer, treating its sentinel as absent.
+
+    AMD SMI reports an unavailable reading in-band: it rewrites the 0xFFFF (or
+    max-uint) the driver answered into the string "N/A" before returning, so a
+    dict otherwise holding numbers can carry a string at any key. A VF is where
+    this surfaces, its host-side telemetry being invisible to the guest.
+
+    Args:
+        dev_info:
+            The answer AMD SMI returned.
+        key:
+            The reading to take.
+        default:
+            What an absent or unavailable reading becomes.
+
+    Returns:
+        The reading, or the default.
+
+    """
+    dev_reading = dev_info.get(key, "N/A")
+    return default if dev_reading == "N/A" else dev_reading
 
 
 def _get_pci_device_name_by_bdf(dev_bdf: str) -> str:

--- a/gpustack_runtime/detector/amd.py
+++ b/gpustack_runtime/detector/amd.py
@@ -138,7 +138,7 @@ class AMDDetector(Detector):
                 )
 
                 dev_gpu_driver_info = pyamdsmi.amdsmi_get_gpu_driver_info(dev)
-                dev_driver_ver = dev_gpu_driver_info.get("driver_version")
+                dev_driver_ver = _get_reading(dev_gpu_driver_info, "driver_version")
 
                 # The operator resolves the name from the local PCI ID database
                 # first: pci.ids knows the board -- the subsystem vendor's name
@@ -158,7 +158,7 @@ class AMDDetector(Detector):
                     ):
                         dev_name = pyamdgpu.amdgpu_get_marketing_name(dev_gpudev)
                 if not dev_name:
-                    dev_name = dev_gpu_asic_info.get("market_name")
+                    dev_name = _get_reading(dev_gpu_asic_info, "market_name", "")
 
                 dev_cc = dev_hsa_agent.compute_capability
                 if not dev_cc:
@@ -212,12 +212,12 @@ class AMDDetector(Detector):
                 # The power limit is inventory, so it stays here, while the used
                 # power the same call carries belongs to the usage query.
                 dev_power = None
-                try:
+                with contextlib.suppress(pyamdsmi.AmdSmiException):
                     dev_power_info = pyamdsmi.amdsmi_get_power_info(dev)
-                    dev_power = (
-                        dev_power_info.get("power_limit", 0) // 1000000
-                    )  # uW to W
-                except pyamdsmi.AmdSmiException:
+                    dev_power_limit = _get_reading(dev_power_info, "power_limit")
+                    if dev_power_limit is not None:
+                        dev_power = dev_power_limit // 1000000  # uW to W
+                if dev_power is None:
                     with contextlib.suppress(pyrocmsmi.ROCMSMIError):
                         dev_power = pyrocmsmi.rsmi_dev_power_cap_get(dev_idx)
 

--- a/gpustack_runtime/detector/hygon.py
+++ b/gpustack_runtime/detector/hygon.py
@@ -349,8 +349,15 @@ class HygonDetector(Detector):
             for dev_idx in range(devs_count):
                 dev_uuid = f"GPU-{pyrocmsmi.rsmi_dev_unique_id_get(dev_idx)[2:]}"
 
-                dev_cores_util = pyrocmsmi.rsmi_dev_busy_percent_get(dev_idx)
-                dev_temp = pyrocmsmi.rsmi_dev_temp_metric_get(dev_idx)
+                # Each reading is isolated on its own, mirroring the AMD path:
+                # ROCm SMI raises on one it cannot serve, and an unwrapped call
+                # would cost the whole sweep rather than the reading.
+                dev_cores_util = None
+                with contextlib.suppress(pyrocmsmi.ROCMSMIError):
+                    dev_cores_util = pyrocmsmi.rsmi_dev_busy_percent_get(dev_idx)
+                dev_temp = None
+                with contextlib.suppress(pyrocmsmi.ROCMSMIError):
+                    dev_temp = pyrocmsmi.rsmi_dev_temp_metric_get(dev_idx)
                 if dev_cores_util is None:
                     debug_log_warning(
                         logger,
@@ -376,7 +383,9 @@ class HygonDetector(Detector):
                         if dev_ecc_count.uncorrectable_err > 0:
                             dev_mem_status = DeviceMemoryStatusEnum.UNHEALTHY
 
-                dev_power_used = pyrocmsmi.rsmi_dev_power_get(dev_idx)
+                dev_power_used = None
+                with contextlib.suppress(pyrocmsmi.ROCMSMIError):
+                    dev_power_used = pyrocmsmi.rsmi_dev_power_get(dev_idx)
 
                 usages.append(
                     Device(

--- a/tests/gpustack_runtime/detector/test_amd.py
+++ b/tests/gpustack_runtime/detector/test_amd.py
@@ -152,7 +152,14 @@ class _FakeRocmSmi:
 
     def rsmi_dev_power_get(self, dev_idx: int) -> int:
         self.calls.append("rsmi_dev_power_get")
-        return self.cards[dev_idx]["power_used"]
+        # A card whose fixture carries no used power stands for the one ROCm
+        # SMI cannot read either -- a VF, where the binding raises rather than
+        # answering the sentinel AMD SMI would.
+        power_used = self.cards[dev_idx]["power_used"]
+        if power_used is None:
+            msg = "power is not supported on this device"
+            raise _FakeRocmSmiError(msg)
+        return power_used
 
 
 class _FakeHSA:
@@ -525,6 +532,56 @@ def test_detect_composes_the_information_and_the_usage(amd_bindings):
     assert devices[0].memory_used == 1024
     assert devices[0].power == 750
     assert devices[0].power_used == 142
+
+
+# --------------------------------------------------------------------------- #
+# AMD SMI's "N/A": an unavailable reading is reported in-band, as a string     #
+# inside a dict otherwise holding numbers. A VF exposes no host-side power     #
+# telemetry, so its driver answers 0xFFFF and the library hands over "N/A".    #
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_usage_falls_back_when_the_sentinel_hides_the_socket_power(
+    amd_bindings,
+):
+    # The sentinel has to route to the ROCm SMI fallback the same way an AMD
+    # SMI failure does -- both mean "AMD SMI cannot tell us the used power".
+    card = _card("0000:05:00.0", "0x00a1b2c3d4e5f600")
+    card["power"]["current_socket_power"] = "N/A"
+    card["power"]["average_socket_power"] = "N/A"
+    calls = amd_bindings([card], agents=[_agent("0000:05:00.0")])
+
+    devices = AMDDetector().detect_usage()
+
+    assert "rsmi_dev_power_get" in calls
+    assert devices[0].power_used == 131
+
+
+def test_detect_usage_reports_no_power_when_no_binding_can_read_it(amd_bindings):
+    # The reported VF: AMD SMI answers the sentinel for both socket readings
+    # and ROCm SMI cannot read the power either, so the field is absent rather
+    # than carrying a string the consumer parses as a number.
+    card = _card("0000:05:00.0", "0x00a1b2c3d4e5f600")
+    card["power"]["current_socket_power"] = "N/A"
+    card["power"]["average_socket_power"] = "N/A"
+    card["power_used"] = None
+    amd_bindings([card], agents=[_agent("0000:05:00.0")])
+
+    devices = AMDDetector().detect_usage()
+
+    assert devices[0].power_used is None
+
+
+def test_detect_usage_reports_no_metrics_when_the_sentinel_hides_them(amd_bindings):
+    card = _card("0000:05:00.0", "0x00a1b2c3d4e5f600")
+    card["metrics"]["average_gfx_activity"] = "N/A"
+    card["metrics"]["temperature_hotspot"] = "N/A"
+    amd_bindings([card], agents=[_agent("0000:05:00.0")])
+
+    devices = AMDDetector().detect_usage()
+
+    assert devices[0].cores_utilization == 0
+    assert devices[0].temperature is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/gpustack_runtime/detector/test_amd.py
+++ b/tests/gpustack_runtime/detector/test_amd.py
@@ -541,6 +541,44 @@ def test_detect_composes_the_information_and_the_usage(amd_bindings):
 # --------------------------------------------------------------------------- #
 
 
+def test_detect_info_falls_back_when_the_sentinel_hides_the_power_limit(amd_bindings):
+    # The limit is floor-divided from uW to W, so a sentinel reaching that
+    # arithmetic raises a TypeError -- which is not an AmdSmiException, so it
+    # escapes the handler and costs the host every AMD card.
+    card = _card("0000:05:00.0", "0x00a1b2c3d4e5f600")
+    card["power"]["power_limit"] = "N/A"
+    calls = amd_bindings([card], agents=[_agent("0000:05:00.0")])
+
+    devices = AMDDetector().detect_info()
+
+    assert "rsmi_dev_power_cap_get" in calls
+    assert devices[0].power == 700
+
+
+def test_detect_info_reports_no_driver_version_when_the_sentinel_hides_it(
+    amd_bindings,
+):
+    card = _card("0000:05:00.0", "0x00a1b2c3d4e5f600")
+    card["driver_info"]["driver_version"] = "N/A"
+    amd_bindings([card], agents=[_agent("0000:05:00.0")])
+
+    devices = AMDDetector().detect_info()
+
+    assert devices[0].driver_version is None
+
+
+def test_detect_info_never_names_a_board_after_the_sentinel(amd_bindings):
+    # The ASIC market name is the last link of the name chain, so a sentinel
+    # there would otherwise be stored as the board's name.
+    card = _card("0000:05:00.0", "0x00a1b2c3d4e5f600")
+    card["asic_info"]["market_name"] = "N/A"
+    amd_bindings([card], pci_ids=None)
+
+    devices = AMDDetector().detect_info()
+
+    assert devices[0].name == ""
+
+
 def test_detect_usage_falls_back_when_the_sentinel_hides_the_socket_power(
     amd_bindings,
 ):

--- a/tests/gpustack_runtime/detector/test_hygon.py
+++ b/tests/gpustack_runtime/detector/test_hygon.py
@@ -244,11 +244,11 @@ class _FakeRocmSmi:
 
     def rsmi_dev_busy_percent_get(self, dev_idx: int) -> int:
         self.calls.append("rsmi_dev_busy_percent_get")
-        return self.cards[dev_idx]["busy_percent"]
+        return self._reading(dev_idx, "busy_percent")
 
     def rsmi_dev_temp_metric_get(self, dev_idx: int) -> int:
         self.calls.append("rsmi_dev_temp_metric_get")
-        return self.cards[dev_idx]["temperature"]
+        return self._reading(dev_idx, "temperature")
 
     def rsmi_dev_power_cap_get(self, dev_idx: int) -> int:
         self.calls.append("rsmi_dev_power_cap_get")
@@ -256,7 +256,17 @@ class _FakeRocmSmi:
 
     def rsmi_dev_power_get(self, dev_idx: int) -> int:
         self.calls.append("rsmi_dev_power_get")
-        return self.cards[dev_idx]["power_used"]
+        return self._reading(dev_idx, "power_used")
+
+    def _reading(self, dev_idx: int, key: str) -> int:
+        # A card whose fixture carries None for a reading stands for the one
+        # ROCm SMI cannot answer: the binding checks every return code and
+        # raises, rather than handing back a sentinel the way AMD SMI does.
+        reading = self.cards[dev_idx][key]
+        if reading is None:
+            msg = f"{key} is not supported on this device"
+            raise _FakeRocmSmiError(msg)
+        return reading
 
     def rsmi_topo_get_numa_node_number(self, dev_idx: int) -> int:
         return self.cards[dev_idx]["numa"]
@@ -626,6 +636,45 @@ def test_detect_composes_the_information_and_the_usage(hygon_bindings):
     assert devices[0].memory == _MEMORY_TOTAL
     assert devices[0].memory_used == 1024
     assert devices[0].power == 350
+    assert devices[0].power_used == 217
+
+
+def test_detect_usage_bounds_an_unreadable_power_to_its_own_card(hygon_bindings):
+    # ROCm SMI raises on a reading it cannot serve, so an unwrapped read takes
+    # the whole sweep down with it and leaves every card on the host with its
+    # information-query values.
+    hygon_bindings(
+        [
+            _card("0000:0b:00.0", "0x9f8e7d6c5b4a3921", power_used=None),
+            _card("0000:0c:00.0", "0x9f8e7d6c5b4a3922"),
+        ],
+        agents=[_agent("0000:0b:00.0"), _agent("0000:0c:00.0")],
+    )
+
+    devices = HygonDetector().detect_usage()
+
+    assert [dev.power_used for dev in devices] == [None, 217]
+    # The rest of the faulty card's usage still arrives, and the healthy card
+    # is untouched.
+    assert [dev.cores_utilization for dev in devices] == [44, 44]
+    assert [dev.temperature for dev in devices] == [51, 51]
+    assert [dev.memory_used for dev in devices] == [1024, 1024]
+
+
+def test_detect_usage_bounds_an_unreadable_utilization_to_its_own_reading(
+    hygon_bindings,
+):
+    # Each reading is isolated on its own, so an unreadable utilization does
+    # not carry off the temperature the next call would have served.
+    hygon_bindings(
+        [_card("0000:0b:00.0", "0x9f8e7d6c5b4a3921", busy_percent=None)],
+        agents=[_agent("0000:0b:00.0")],
+    )
+
+    devices = HygonDetector().detect_usage()
+
+    assert devices[0].cores_utilization == 0
+    assert devices[0].temperature == 51
     assert devices[0].power_used == 217
 
 


### PR DESCRIPTION
## What

`gpustack-runtime detect --format json` on an AMD Instinct MI300X **VF** emitted `"power_used": "N/A"`, which the consumer cannot parse:

```
gpustack.worker.collector - ERROR - Failed to detect GPU devices:
1 validation error for GPUDeviceStatus
power_used
  Input should be a valid number, unable to parse string as a number
  [type=float_parsing, input_value='N/A', input_type=str]
```

`pyamdsmi` is not an in-house ctypes binding — it is `from amdsmi import *`, a bridge over AMD's **official** Python library. That library reports an unavailable reading **in-band**, rewriting the `0xFFFF` / max-uint the driver answered into the **string `"N/A"`** inside dicts that otherwise hold numbers (`amdsmi_interface.py:2594` for the whole power dict, `:698` `_validate_if_max_uint` for the metrics). On a VF the host-side power telemetry is not exposed to the guest, the driver answers `0xFFFF`, and amdsmi hands over `"N/A"`. The detector defended against this convention at only 2 of 8 read sites and took every other reading at face value.

- **`_get_reading()`** — one private helper in `amd.py` mapping an AMD SMI reading to a value or a default, so the convention lives in one place instead of at six call sites. It is deliberately not `safe_int`/`safe_str`: those coerce, and this must be able to answer "absent" so a fallback can run.
- **Usage query** — a sentinel `current_socket_power`/`average_socket_power` now routes to the ROCm SMI fallback exactly the way a failed AMD SMI call already did (both mean "AMD SMI cannot tell the used power"); a sentinel `average_gfx_activity`/`temperature_hotspot` counts as absent, letting the existing "unreadable utilization is 0" guard do its job. Uses `is None`, so a genuine 0 W reading is not mistaken for a missing one.
- **Inventory query** — a sentinel `power_limit` falls back to `rsmi_dev_power_cap_get` instead of being floor-divided. **This was worse than the reported symptom:** `"N/A" // 1000000` raises `TypeError`, which is not an `AmdSmiException`, so it escaped the handler and dropped the vendor — a host loses *every* AMD card. This machine's limit happened to be valid (750 W), which is the only reason it surfaced as a bad `power_used` instead. A sentinel `driver_version` / `market_name` is likewise no longer stored as a version or a board name.
- **Hygon** — a different, symmetric gap, not a sentinel one: `pyrocmsmi` checks every return code and raises instead of answering a sentinel, but the busy-percent, temperature and used-power reads were unwrapped where the AMD path wraps each equivalent call, so one unreadable metric raised out of `detect_usage` and cost the whole batch. Each is now isolated on its own. Isolation only — no sentinel checks added.

**Not a regression.** `git log -S` puts every one of these readings in `f64a307 refactor: support amd detection` (2025-09-23), the commit that introduced AMD support, in the form they still had. `518db70` (#17) only moved the block from `detect()` into `detect_usage()`.

**Other vendors are unaffected.** Of the twelve bindings only three bridge a third-party library: `pyamdsmi` (the sentinel), `pynvml` and `pymtml`. pynvml's `"N/A"` occurrences all live in `pynvml_utils/smi.py`, the nvidia-smi table renderer; the core API this project calls signals unavailability by raising `NVMLError`. The other nine are in-house `ctypes`/`CDLL` bindings that return numbers and raise on failure, so they cannot produce a string sentinel.

## Test plan

- `uv run pytest tests/` — **613 passed, 20 skipped** (was 605/20; 8 new guards). All new guards were re-run against `main`'s source and **all 7 code-path guards fail there**, so none is vacuous.
  - `test_amd.py` — the four leak paths: both socket readings `"N/A"` (falls back, then reports `None` when ROCm SMI also cannot read it), `power_limit` `"N/A"` (no `TypeError`, falls back to the 700 W cap), metrics `"N/A"` (`cores_utilization == 0`, `temperature is None`), `driver_version` / `market_name` `"N/A"`.
  - `test_hygon.py` — an unreadable power is bounded to its own card while the rest of that card's usage and the healthy card are untouched; an unreadable utilization does not carry off the temperature.
  - Both fake bindings gained one convention: a card whose fixture carries `None` for a reading stands for the one the binding cannot answer, and raises.
- **Confirmed on the reported hardware** (`root@134.199.204.73`, container `02132c6df882`, AMD Instinct MI300X VF, driver 6.19.14.31400000). The container's `amd.py` was byte-identical to this branch's base, so the fixed file was dropped in and the container restarted:

  | | Before | After |
  | --- | --- | --- |
  | `detect --format json` | `"power_used": "N/A"` | `"power_used": null` |
  | `gpustack.worker.collector` | 1250 `float_parsing` failures, one per 5 s poll | none |
  | Exported GPU metrics | none — detection failed outright | `worker_node_gpu_info`, `gpu_cores` 304, `gpu_power_limit_watts` 750 |

  ROCm SMI cannot read the power on this VF either, which is why the field lands on `null` rather than a number — the intended outcome. The host was left running the patch; it does not survive recreating the container from the image.

## Notes

The operator carries the same defect against the same hardware fact, in its own shape: `binding/amdsmi` is an in-house cgo binding, so it sees the raw integer and never a `"N/A"` string — quieter, not safer. Nothing crashes and `65535` is reported as a real measurement into monitoring and scheduling (`PowerUsage` W, `CoresUtilization` %, `Temperature` °C). That fix is **out of scope here** and is being made separately in `gpustack.ai/gpustack`, where the same block sits at `pkg/devicemanager/detector/amd/device.go:315,316,323-325`. Its Hygon detector already checks `ret` per reading and needs no change.

One asymmetry worth recording: the Python side gets an accidental layer of cover the Go side lacks — amdsmi's `_validate_if_max_uint(..., isActivity=True)` also rejects activity readings above 100.